### PR TITLE
Added functionality to place requests on GitHub API.

### DIFF
--- a/src/AdamWathan/EloquentOAuth/OAuthManager.php
+++ b/src/AdamWathan/EloquentOAuth/OAuthManager.php
@@ -54,7 +54,7 @@ class OAuthManager
         return $this->stateManager->generateState();
     }
 
-    protected function getProvider($providerAlias)
+    public function getProvider($providerAlias)
     {
         if (! $this->hasProvider($providerAlias)) {
             throw new ProviderNotRegisteredException("No provider has been registered under the alias '{$providerAlias}'");

--- a/src/AdamWathan/EloquentOAuth/Providers/GitHubProvider.php
+++ b/src/AdamWathan/EloquentOAuth/Providers/GitHubProvider.php
@@ -4,9 +4,10 @@ use AdamWathan\EloquentOAuth\Exceptions\InvalidAuthorizationCodeException;
 
 class GitHubProvider extends Provider
 {
-	protected $authorizeUrl = "https://github.com/login/oauth/authorize";
-	protected $accessTokenUrl = "https://github.com/login/oauth/access_token";
-	protected $userDataUrl = "https://api.github.com/user";
+	protected $baseUrl = "https://github.com";
+	protected $authorizeUrl = $baseUrl . "/login/oauth/authorize";
+	protected $accessTokenUrl = $baseUrl . "/login/oauth/access_token";
+	protected $userDataUrl = $baseUrl . "/user";
 	protected $scope = array(
         'user:email',
 	);
@@ -20,6 +21,12 @@ class GitHubProvider extends Provider
 			'Accept' => 'application/vnd.github.v3'
 		),
 	);
+	
+	public function request($uri, $accessToken)
+	{
+		$uri = ((substr($uri, 0, 1) != '/') ? '/' : '') . $uri;
+		return $this->getJson($this->getRequestUrl($baseUrl . $uri . "?access_token=" . $accessToken), []);
+	}
 
 	protected function getAuthorizeUrl()
 	{

--- a/src/AdamWathan/EloquentOAuth/Providers/Provider.php
+++ b/src/AdamWathan/EloquentOAuth/Providers/Provider.php
@@ -45,7 +45,7 @@ abstract class Provider implements ProviderInterface
 		$url .= '?' . $this->buildAuthorizeQueryString($state);
 		return $url;
 	}
-
+	
 	protected function buildAuthorizeQueryString($state)
 	{
 		$queryString = "client_id=".$this->clientId;


### PR DESCRIPTION
I added in the initial functionality needed to place requests on the GitHub API. This could/should probably be extracted out to the other providers as well. Also, it could probably use some refactoring to be more accessible through the OAuthManager Facade, or something.

I can then do the following, for example:

``` php
    public function index($nickname = null)
    {
        $user = User::whereNickname($nickname)->first();
        $gitHubProvider = OAuth::getProvider('github');
dd($gitHubProvider->request('/users/' . $nickname . '/gists', $user->gitHubAccessToken));
    }
```

I think it is important to keep the access token configurable, but could default to the logged in user if left blank. That way I can issue requests on behalf of different users that are authenticated in my system.

Please let me know what you think. I have implemented it in this rudimentary fashion for now to get up and running, but would be happy to discuss cleaning it up with you, and discuss how you think it should work.

All the best,
~Mike
