### PR TITLE
Start implementation of Guzzle 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/session": "4.*",
         "illuminate/database": "4.*",
         "illuminate/support": "4.*",
-        "guzzle/guzzle": "~3.7"
+        "guzzle/guzzle": "~4.0"
     },
     "require-dev": {
         "mockery/mockery": "0.8.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/session": "4.*",
         "illuminate/database": "4.*",
         "illuminate/support": "4.*",
-        "guzzle/guzzle": "~4.0"
+        "guzzlehttp/guzzle": "~4.0"
     },
     "require-dev": {
         "mockery/mockery": "0.8.0"

--- a/src/AdamWathan/EloquentOAuth/EloquentOAuthServiceProvider.php
+++ b/src/AdamWathan/EloquentOAuth/EloquentOAuthServiceProvider.php
@@ -1,7 +1,7 @@
 <?php namespace AdamWathan\EloquentOAuth;
 
 use Illuminate\Support\ServiceProvider;
-use Guzzle\Http\Client as HttpClient;
+use Guzzle\HttpClient as HttpClient;
 
 class EloquentOAuthServiceProvider extends ServiceProvider {
 

--- a/src/AdamWathan/EloquentOAuth/EloquentOAuthServiceProvider.php
+++ b/src/AdamWathan/EloquentOAuth/EloquentOAuthServiceProvider.php
@@ -1,7 +1,7 @@
 <?php namespace AdamWathan\EloquentOAuth;
 
 use Illuminate\Support\ServiceProvider;
-use Guzzle\HttpClient as HttpClient;
+use GuzzleHttp\Client as HttpClient;
 
 class EloquentOAuthServiceProvider extends ServiceProvider {
 

--- a/src/AdamWathan/EloquentOAuth/Providers/Provider.php
+++ b/src/AdamWathan/EloquentOAuth/Providers/Provider.php
@@ -4,7 +4,7 @@ use AdamWathan\EloquentOAuth\ProviderUserDetails as UserDetails;
 use AdamWathan\EloquentOAuth\Exceptions\ApplicationRejectedException;
 use AdamWathan\EloquentOAuth\Exceptions\InvalidAuthorizationCodeException;
 use Illuminate\Http\Request as Input;
-use Guzzle\HttpClient as HttpClient;
+use GuzzleHttp\Client as HttpClient;
 
 abstract class Provider implements ProviderInterface
 {

--- a/src/AdamWathan/EloquentOAuth/Providers/Provider.php
+++ b/src/AdamWathan/EloquentOAuth/Providers/Provider.php
@@ -4,7 +4,7 @@ use AdamWathan\EloquentOAuth\ProviderUserDetails as UserDetails;
 use AdamWathan\EloquentOAuth\Exceptions\ApplicationRejectedException;
 use AdamWathan\EloquentOAuth\Exceptions\InvalidAuthorizationCodeException;
 use Illuminate\Http\Request as Input;
-use Guzzle\Http\Client as HttpClient;
+use Guzzle\HttpClient as HttpClient;
 
 abstract class Provider implements ProviderInterface
 {

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -19,7 +19,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\Http\\Client')->shouldIgnoreMissing();
+        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -37,7 +37,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\Http\\Client')->shouldIgnoreMissing();
+        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -56,7 +56,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\Http\\Client')->shouldIgnoreMissing();
+        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -87,7 +87,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\Http\\Client')->shouldIgnoreMissing();
+        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -19,7 +19,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
+        $httpClient = M::mock('GuzzleHttp\\Client')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -37,7 +37,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
+        $httpClient = M::mock('GuzzleHttp\\Client')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -56,7 +56,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
+        $httpClient = M::mock('GuzzleHttp\\Client')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);
@@ -87,7 +87,7 @@ class ProviderTest extends PHPUnit_Framework_TestCase
             'secret' => 'foobar',
             'redirect' => $redirectUri,
             );
-        $httpClient = M::mock('Guzzle\\HttpClient')->shouldIgnoreMissing();
+        $httpClient = M::mock('GuzzleHttp\\Client')->shouldIgnoreMissing();
         $input = M::mock('Illuminate\\Http\\Request')->shouldIgnoreMissing();
 
         $provider = new Provider($config, $httpClient, $input);


### PR DESCRIPTION
This serves as a starting point for Guzzle 4.x where the namespaces have changed. I haven't been able to get this to work yet, it seems like the data sent to the token url isn't correct (probably due to changed calls).

Details on migrating from 3.x to 4.0 are here:
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#3x-to-40