### PR TITLE
Update existing oauth_identities instead of flushing all and creating new

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -40,7 +40,7 @@ class Authenticator
     protected function updateUser($user, $provider, $details)
     {
         $this->users->store($user);
-        $this->storeAccessToken($user, $provider, $details);
+        $this->storeProviderIdentity($user, $provider, $details);
     }
 
     protected function getExistingUser($provider, $details)
@@ -49,23 +49,23 @@ class Authenticator
         return $this->users->findByIdentity($identity);
     }
 
-    protected function storeAccessToken($user, $provider, ProviderUserDetails $details)
+    protected function storeProviderIdentity($user, $provider, ProviderUserDetails $details)
     {
         if ($this->identities->userExists($provider, $details)) {
-            $this->updateAccessToken($provider, $details);
+            $this->updateProviderIdentity($provider, $details);
         } else {
-            $this->addAccessToken($user, $provider, $details);
+            $this->addProviderIdentity($user, $provider, $details);
         }
     }
 
-    protected function updateAccessToken($provider, ProviderUserDetails $details)
+    protected function updateProviderIdentity($provider, ProviderUserDetails $details)
     {
         $identity = $this->identities->getByProvider($provider, $details);
         $identity->access_token = $details->accessToken;
         $this->identities->store($identity);
     }
 
-    protected function addAccessToken($user, $provider, ProviderUserDetails $details)
+    protected function addProviderIdentity($user, $provider, ProviderUserDetails $details)
     {
         $identity = new OAuthIdentity;
         $identity->user_id = $user->getKey();

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -40,7 +40,7 @@ class Authenticator
     protected function updateUser($user, $provider, $details)
     {
         $this->users->store($user);
-        $this->updateAccessToken($user, $provider, $details);
+        $this->storeAccessToken($user, $provider, $details);
     }
 
     protected function getExistingUser($provider, $details)
@@ -49,15 +49,20 @@ class Authenticator
         return $this->users->findByIdentity($identity);
     }
 
-    protected function updateAccessToken($user, $provider, ProviderUserDetails $details)
+    protected function storeAccessToken($user, $provider, ProviderUserDetails $details)
     {
-        $this->flushAccessTokens($user, $provider);
-        $this->addAccessToken($user, $provider, $details);
+        if ($this->identities->userExists($provider, $details)) {
+            $this->updateAccessToken($user, $provider, $details);
+        } else {
+            $this->addAccessToken($user, $provider, $details);
+        }
     }
 
-    protected function flushAccessTokens($user, $provider)
+    protected function updateAccessToken($user, $provider, ProviderUserDetails $details)
     {
-        $this->identities->flush($user, $provider);
+        $identity = $this->identities->getByProvider($provider, $details);
+        $identity->access_token = $details->accessToken;
+        $this->identities->store($identity);
     }
 
     protected function addAccessToken($user, $provider, ProviderUserDetails $details)

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -52,13 +52,13 @@ class Authenticator
     protected function storeAccessToken($user, $provider, ProviderUserDetails $details)
     {
         if ($this->identities->userExists($provider, $details)) {
-            $this->updateAccessToken($user, $provider, $details);
+            $this->updateAccessToken($provider, $details);
         } else {
             $this->addAccessToken($user, $provider, $details);
         }
     }
 
-    protected function updateAccessToken($user, $provider, ProviderUserDetails $details)
+    protected function updateAccessToken($provider, ProviderUserDetails $details)
     {
         $identity = $this->identities->getByProvider($provider, $details);
         $identity->access_token = $details->accessToken;

--- a/tests/AuthenticatorTest.php
+++ b/tests/AuthenticatorTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as M;
 use AdamWathan\EloquentOAuth\Authenticator;
+use AdamWathan\EloquentOAuth\OAuthIdentity;
 
 class AuthenticatorTest extends PHPUnit_Framework_TestCase
 {
@@ -36,7 +37,7 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
         $identities  = M::mock('AdamWathan\\EloquentOAuth\\IdentityStore')->shouldIgnoreMissing();
 
         $userDetails = M::mock('AdamWathan\\EloquentOAuth\\ProviderUserDetails');
-        $identity = M::mock('AdamWathan\\EloquentOAuth\\OAuthIdentity');
+        $identity = new OAuthIdentity;
 
         $user = M::mock('stdClass')->shouldIgnoreMissing();
 


### PR DESCRIPTION
Preserves the ID, because why not.