### PR TITLE
Allow overriding user by returning a user from the callback

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -16,9 +16,7 @@ class Authenticator
     public function login($providerAlias, $userDetails, $callback = null)
     {
         $user = $this->getUser($providerAlias, $userDetails);
-        if ($callback) {
-            $callback($user, $userDetails);
-        }
+        $user = $this->runCallback($callback, $user, $userDetails);
         $this->updateUser($user, $providerAlias, $userDetails);
         $this->auth->login($user);
     }
@@ -29,6 +27,13 @@ class Authenticator
             return $this->getExistingUser($providerAlias, $details);
         }
         return $this->users->create();
+    }
+
+    protected function runCallback($callback, $user, $userDetails)
+    {
+        $callback = $callback ?: function () {};
+        $callbackUser = $callback($user, $userDetails);
+        return $callbackUser ?: $user;
     }
 
     protected function updateUser($user, $providerAlias, $details)

--- a/tests/AuthenticatorTest.php
+++ b/tests/AuthenticatorTest.php
@@ -36,15 +36,20 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
     public function test_login_uses_existing_user_if_matching_user_exists()
     {
         $providerAlias = 'provider';
-        $auth = M::spy();
-        $users  = M::spy();
-        $identities  = M::spy();
+
         $userDetails = new SocialNormUser([]);
         $user = M::mock('Illuminate\Contracts\Auth\Authenticatable')->shouldIgnoreMissing();
 
-        $identities->shouldReceive('userExists')->andReturn(true);
-        $identities->shouldReceive('getByProvider')->andReturn(new OAuthIdentity);
-        $users->shouldReceive('findByIdentity')->andReturn($user);
+        $auth = M::spy();
+
+        $users  = M::spy([
+            'findByIdentity' => $user
+        ]);
+
+        $identities  = M::spy([
+            'userExists' => true,
+            'getByProvider' => new OAuthIdentity,
+        ]);
 
         $authenticator = new Authenticator($auth, $users, $identities);
         $authenticator->login('provider', $userDetails);
@@ -53,5 +58,65 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
         $users->shouldHaveReceived('store')->with($user);
         $identities->shouldHaveReceived('store');
         $auth->shouldHaveReceived('login')->with($user);
+    }
+
+    public function test_if_a_user_is_returned_from_the_callback_that_user_is_used()
+    {
+        $providerAlias = 'provider';
+
+        $userDetails = new SocialNormUser([]);
+        $user = M::mock('Illuminate\Contracts\Auth\Authenticatable')->shouldIgnoreMissing();
+        $otherUser = M::mock('Illuminate\Contracts\Auth\Authenticatable')->shouldIgnoreMissing();
+
+        $auth = M::spy();
+
+        $users  = M::spy([
+            'findByIdentity' => $user
+        ]);
+
+        $identities  = M::spy([
+            'userExists' => true,
+            'getByProvider' => new OAuthIdentity,
+        ]);
+
+        $authenticator = new Authenticator($auth, $users, $identities);
+        $authenticator->login('provider', $userDetails, function () use ($otherUser) {
+            return $otherUser;
+        });
+
+        $users->shouldNotHaveReceived('create');
+        $users->shouldHaveReceived('store')->with($otherUser);
+        $identities->shouldHaveReceived('store');
+        $auth->shouldHaveReceived('login')->with($otherUser);
+    }
+
+    public function test_if_nothing_is_returned_from_the_callback_the_found_or_created_user_is_used()
+    {
+        $providerAlias = 'provider';
+
+        $userDetails = new SocialNormUser([]);
+        $foundUser = M::mock('Illuminate\Contracts\Auth\Authenticatable')->shouldIgnoreMissing();
+        $otherUser = M::mock('Illuminate\Contracts\Auth\Authenticatable')->shouldIgnoreMissing();
+
+        $auth = M::spy();
+
+        $users  = M::spy([
+            'findByIdentity' => $foundUser
+        ]);
+
+        $identities  = M::spy([
+            'userExists' => true,
+            'getByProvider' => new OAuthIdentity,
+        ]);
+
+        $authenticator = new Authenticator($auth, $users, $identities);
+        $authenticator->login('provider', $userDetails, function () {
+            return;
+        });
+
+        $users->shouldNotHaveReceived('create');
+        $users->shouldHaveReceived('store')->with($foundUser);
+        $identities->shouldHaveReceived('store');
+        $auth->shouldHaveReceived('login')->with($foundUser);
     }
 }


### PR DESCRIPTION
This PR allows overriding the user to be logged in by returning a user from the optional closure passed to `login()`.

For example, if you supported multiple social login methods and wanted to match users based on email to prevent duplicate accounts, you could do something like this:

```php
SocialAuth::login($provider, function ($user, $details) {
    $existingUser = User::where('email', $details->email)->first();

    if ($existingUser) {
        return $existingUser;
    }

    $user->email = $details->email;
});
```

If you manually return a different user than the package finds/builds for you, no additional user will get created in the database.

I still believe matching users based on email is a significant security vulnerability and I wouldn't recommend it, but I'm a libertarian, so do what you will :)